### PR TITLE
docs: add repository links to note articles

### DIFF
--- a/docs/05.articles/note_a2a_advanced_level3.md
+++ b/docs/05.articles/note_a2a_advanced_level3.md
@@ -94,7 +94,7 @@ layers:
     - Event Store
 ```
 
-### 🔧 実装パターン
+### 🔧 実装パターン（[実装例](https://github.com/tkosht/cursor_dev/tree/main/app/a2a)）
 
 #### 1. Saga パターンによる分散トランザクション
 
@@ -436,7 +436,7 @@ class A2AMetrics:
 
 ### 📞 次のアクション
 
-1. **技術評価**: POCプロジェクトの立ち上げ
+1. **技術評価**: POCプロジェクトの立ち上げ（[リファレンス実装](https://github.com/tkosht/cursor_dev)を参考に）
 2. **ビジネスケース作成**: ROI分析の詳細化
 3. **パートナー選定**: 実装支援ベンダーの評価
 4. **人材育成**: A2Aアーキテクトの養成

--- a/docs/05.articles/note_a2a_introduction_level1.md
+++ b/docs/05.articles/note_a2a_introduction_level1.md
@@ -134,7 +134,7 @@ class SimpleTaskAgent:
         return {"success": True, "data": self.tasks}
 ```
 
-### 🚀 使ってみる
+### 🚀 使ってみる（[完全な実装例はこちら](https://github.com/tkosht/cursor_dev)）
 
 ```python
 # エージェントを作成
@@ -181,7 +181,7 @@ print(response)
 
 ### 🚀 次に挑戦してみよう
 
-1. **サンプルコードを拡張**: 
+1. **サンプルコードを拡張**: ([実装例はこちら](https://github.com/tkosht/cursor_dev/tree/main/app/a2a))
    - タスクの削除機能を追加
    - タスクの完了状態を変更する機能
    
@@ -196,8 +196,10 @@ print(response)
 
 ### 📚 さらに学ぶには
 
-- **中級編**: 「A2A実践ガイド：本格的なエージェント開発」
-- **上級編**: 「エンタープライズA2A：大規模システムでの活用」
+- **実装サンプル**: [cursor_dev リポジトリ](https://github.com/tkosht/cursor_dev) - 本記事のコードを含む完全な実装例
+- **クイックスタート**: [A2Aエージェント開発 クイックセットアップガイド](a2a_quick_setup_guide.md) - 環境構築の詳細手順
+- **中級編**: [A2A実践ガイド：本格的なエージェント開発](note_a2a_practice_level2.md)
+- **上級編**: [エンタープライズA2A：大規模システムでの活用](note_a2a_advanced_level3.md)
 - **公式ドキュメント**: [A2A Protocol Specification](https://github.com/anthropics/a2a-protocol)
 
 ### 💬 コミュニティ

--- a/docs/05.articles/note_a2a_practice_level2.md
+++ b/docs/05.articles/note_a2a_practice_level2.md
@@ -12,7 +12,7 @@
 
 ### 🎯 この記事のゴール
 
-3日間で以下を達成した実践記録をもとに、あなたも同じ品質のシステムを構築できるようになります：
+3日間で以下を達成した実践記録をもとに、あなたも同じ品質のシステムを構築できるようになります（[実装コードはこちら](https://github.com/tkosht/cursor_dev)）：
 
 - **テストカバレッジ92%**のA2Aエージェント
 - **101個の自動テスト**による品質保証
@@ -56,7 +56,11 @@ tests/
 ### 🛠️ 必須ツールのセットアップ
 
 ```bash
-# プロジェクト初期化
+# プロジェクト初期化（テンプレートから開始する場合）
+git clone https://github.com/tkosht/cursor_dev.git a2a-agent
+cd a2a-agent
+
+# または新規作成
 mkdir a2a-agent && cd a2a-agent
 poetry init
 
@@ -843,7 +847,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 
 このプロジェクトで得た知見を共有します：
 
-- **GitHub**: [完全なソースコード](https://github.com/yourusername/a2a-tdd)
+- **GitHub**: [完全なソースコード](https://github.com/tkosht/cursor_dev) - 本記事で紹介した全実装
 - **ブログ**: 詳細な実装解説
 - **勉強会**: TDD実践ワークショップ
 


### PR DESCRIPTION
This PR adds repository links to all note article markdown files.

## Changes
- Added repository links to 3 note articles in `docs/05.articles/`
- Fixed placeholder GitHub link in Level 2 article
- Added cross-references between different article levels
- Included links to specific implementation examples

Closes #13

Generated with [Claude Code](https://claude.ai/code)