### PR TITLE
Fix: Add tmux Enter別送信 protocol pathway to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ function display_mandatory_rules_checklist() {
     echo "📚 MANDATORY REFERENCES:"
     echo "   • memory-bank/00-core/*mandatory*.md"
     echo "   • memory-bank/11-checklist-driven/checklist_driven_execution_framework.md"
+    echo "   • memory-bank/02-organization/tmux_organization_success_patterns.md (for tmux activities)"
     echo ""
     read -p "❓ Confirm ALL mandatory rules verified before starting task (y/N): " confirmation
     [[ "$confirmation" != "y" && "$confirmation" != "Y" ]] && return 1
@@ -89,7 +90,8 @@ PRE_EXECUTION_MANDATORY=(
     "2. AI COMPLIANCE: Run pre_action_check.py --strict-mode"
     "3. WORK MANAGEMENT: Verify on feature branch (verify_work_management)"
     "4. KNOWLEDGE LOAD: Execute smart_knowledge_load() for domain context"
-    "5. QUALITY GATES: Execute before ANY commit"
+    "5. TMUX PROTOCOLS: For tmux activities, ensure Enter別送信 compliance"
+    "6. QUALITY GATES: Execute before ANY commit"
 )
 ```
 
@@ -172,6 +174,7 @@ FORBIDDEN=("probably" "maybe" "I think" "seems like")
 | **Commands** | Essential reference | `memory-bank/09-meta/essential_commands_reference.md` |
 | **Cognee Ops** | Strategic hub | `memory-bank/01-cognee/cognee_strategic_operations_hub.md` |
 | **AI Coordination** | Complete guide | `memory-bank/02-organization/ai_coordination_comprehensive_guide.md` |
+| **tmux Organization** | SUCCESS PATTERNS | `memory-bank/02-organization/tmux_organization_success_patterns.md` |
 | **Quality Review** | Framework | `memory-bank/04-quality/enhanced_review_process_framework.md` |
 | **Detailed Impl** | Full guide | `CLAUDE_structured.md` |
 
@@ -182,10 +185,11 @@ FORBIDDEN=("probably" "maybe" "I think" "seems like")
 1. ✓ AI COMPLIANCE: python scripts/pre_action_check.py --strict-mode
 2. ✓ WORK MANAGEMENT: Verify on task branch (not main/master)
 3. ✓ KNOWLEDGE LOAD: smart_knowledge_load "domain"
-4. ✓ TDD FOUNDATION: Write test FIRST
-5. ✓ FACT VERIFICATION: No speculation allowed
-6. ✓ QUALITY GATES: Before commit
-7. ✓ COMPLETION: Create Pull Request when done
+4. ✓ TMUX PROTOCOLS: For any tmux organization activity, read tmux_organization_success_patterns.md
+5. ✓ TDD FOUNDATION: Write test FIRST
+6. ✓ FACT VERIFICATION: No speculation allowed
+7. ✓ QUALITY GATES: Before commit
+8. ✓ COMPLETION: Create Pull Request when done
 ```
 
 **Key Principle**: 事実ベース判断 - No speculation, only verified facts.


### PR DESCRIPTION
## Summary
• Fixed critical knowledge access gap for tmux Enter別送信 protocol
• Added direct reference to tmux_organization_success_patterns.md in CLAUDE.md navigation
• Included tmux protocol compliance in mandatory execution checklist
• Ensured Enter別送信 requirements are part of pre-execution verification

## Background
Analysis revealed that the Enter別送信 (separate Enter sending) protocol was properly documented in tmux_organization_success_patterns.md but not accessible through standard CLAUDE.md knowledge loading pathways. This created a critical gap where essential tmux communication protocols could be missed.

## Changes Made
1. **Navigation Guide**: Added tmux Organization → SUCCESS PATTERNS reference
2. **Execution Checklist**: Added tmux protocols verification step
3. **Mandatory References**: Included tmux_organization_success_patterns.md for tmux activities  
4. **Pre-Execution Requirements**: Added Enter別送信 compliance check

## Impact
- ✅ Direct access to tmux protocols from CLAUDE.md
- ✅ Mandatory verification of Enter別送信 compliance
- ✅ Prevents tmux communication failures in organizational activities
- ✅ Maintains 100% success rate of Team04 proven patterns

## Test plan
- [x] Verify tmux_organization_success_patterns.md is now directly referenced in CLAUDE.md
- [x] Confirm Enter別送信 protocol is included in mandatory execution checklist
- [x] Validate knowledge access pathway from CLAUDE.md to tmux protocols
- [x] Security and documentation accuracy checks passed

🤖 Generated with [Claude Code](https://claude.ai/code)