### PR TITLE
feat(bin): add Cursor CLI installer script

### DIFF
--- a/bin/install_cursorcli.sh
+++ b/bin/install_cursorcli.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/sh
+curl https://cursor.com/install -fsS | bash


### PR DESCRIPTION
## Summary
- Add `bin/install_cursorcli.sh` to install Cursor CLI via curl | bash

## Test plan
- Run script: bash bin/install_cursorcli.sh (manual)
- Verify `cursor` command availability after install

## Notes
- Minimal installer; no env changes included.