### PR TITLE
feat(cursor): add MCP servers config (.cursor/mcp.json)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    "serena": {
+      "url": "http://localhost:9121/sse"
+    },
+    "cognee": {
+      "command": "sh",
+      "args": ["bin/run_cognee.sh"]
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add `.cursor/mcp.json` to configure MCP servers for local development
  - **sequential-thinking**: via `npx @modelcontextprotocol/server-sequential-thinking`
  - **serena**: SSE endpoint `http://localhost:9121/sse`
  - **cognee**: shell launcher `bin/run_cognee.sh`

## Context
This enables Cursor MCP integrations used in this repo (Serena/Cognee), aligning local workflows with the documented setup.

## Changes
- New file: `.cursor/mcp.json`

## Test plan
- Open this repo in Cursor
- Confirm MCP servers are recognized and available
- Start `bin/run_cognee.sh` and check connection